### PR TITLE
Fix for broken config file publication

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -20,7 +20,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     public function boot()
     {
         $this->publishes([
-            __DIR__.'/config/api-tester.php' => config_path('api-tester.php'),
+            __DIR__.'/../config/api-tester.php' => config_path('api-tester.php'),
         ], 'config');
     }
 }


### PR DESCRIPTION
Fixed a broken link: to enable publication of the configuration (`config/api-tester.php`) through the existing `php artisan vendor:publish --provider="Asvae\ApiTester\ServiceProvider"` artisan command.